### PR TITLE
Move Docker section in the docs

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -57,9 +57,9 @@ nav:
   - Home: index.md
   - intro.md
   - Install:
-    - install/docker.md
     - install/linux.md
     - install/windows.md
+    - install/docker.md
     - install/npm.md
     - install/source.md
   - quick-start.md


### PR DESCRIPTION
Move Docker section in the docs below Linux and Windows, due to the limited functionality of Compose Generator when running inside a container