### PR TITLE
Fix bug with bind volumes on Windows

### DIFF
--- a/src/pass/generate/gen_copy_volumes.go
+++ b/src/pass/generate/gen_copy_volumes.go
@@ -33,8 +33,9 @@ func GenerateCopyVolumes(project *model.CGProject, selected *model.SelectedTempl
 	// Change volume paths in composition to the new ones
 	for serviceIndex, service := range project.Composition.Services {
 		for volumeIndex, volume := range service.Volumes {
-			if strings.Contains(volume.Source, getPredefinedServicesPath()) {
-				dstPath := volume.Source[len(getPredefinedServicesPath()):]
+			srcPath := filepath.ToSlash(volume.Source)
+			if strings.Contains(srcPath, getPredefinedServicesPath()) {
+				dstPath := srcPath[len(getPredefinedServicesPath()):]
 				dstPath = project.Composition.WorkingDir + strings.Join(strings.Split(dstPath, "/")[3:], "/")
 				project.Composition.Services[serviceIndex].Volumes[volumeIndex].Source = dstPath
 			}


### PR DESCRIPTION
Hotfix: Bug with Windows bind volumes due to backslashes instead of slashes in file paths